### PR TITLE
OroCommerce 5.0 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.7",
+        "phpstan/phpstan": "^1.8",
         "phpmd/phpmd": "^2.12",
         "friendsofphp/php-cs-fixer": "~2.18.2 || ~2.19.0",
         "symfony/phpunit-bridge": "~4.4.24 || ~6.1.0",

--- a/src/Aligent/InvoiceBundle/Controller/InvoiceController.php
+++ b/src/Aligent/InvoiceBundle/Controller/InvoiceController.php
@@ -19,7 +19,7 @@ class InvoiceController extends AbstractController
 {
     /**
      * @Route("/", name="aligent_invoice_index")
-     * @Template("AligentInvoiceBundle:AligentInvoice:index.html.twig")
+     * @Template("@AligentInvoice/AligentInvoice/index.html.twig")
      * @Acl(
      *      id="aligent_invoice_view",
      *      type="entity",
@@ -37,7 +37,7 @@ class InvoiceController extends AbstractController
 
     /**
      * @Route("/view/{id}", name="aligent_invoice_view", requirements={"id"="\d+"})
-     * @Template("AligentInvoiceBundle:AligentInvoice:view.html.twig")
+     * @Template("@AligentInvoice/AligentInvoice/view.html.twig")
      *
      * @param Invoice $invoice
      * @return array<string,mixed>

--- a/src/Aligent/InvoiceBundle/Factory/InvoicePaymentFactory.php
+++ b/src/Aligent/InvoiceBundle/Factory/InvoicePaymentFactory.php
@@ -79,7 +79,7 @@ class InvoicePaymentFactory
             ->setCustomerUser($customerUser)
             ->setCustomer($customerUser->getCustomer())
             ->setActive(true)
-            ->setPaymentMethod(''); // NOTE: This column is non-nullable
+            ->setPaymentMethod('') // NOTE: This column is non-nullable
         ;
 
         return $this->setInvoices($invoicePayment, $invoices);

--- a/src/Aligent/InvoiceBundle/Resources/config/controllers.yml
+++ b/src/Aligent/InvoiceBundle/Resources/config/controllers.yml
@@ -2,7 +2,19 @@ services:
     _defaults:
         public: true
 
+    Aligent\InvoiceBundle\Controller\InvoiceController:
+        calls:
+            - ['setContainer', ['@Psr\Container\ContainerInterface']]
+        tags:
+            - { name: container.service_subscriber }
+
     Aligent\InvoiceBundle\Controller\Frontend\FrontendInvoiceController:
+        arguments:
+            - '@oro_form.update_handler'
+            - '@Aligent\InvoiceBundle\Provider\FrontendInvoiceProvider'
+            - '@Aligent\InvoiceBundle\Factory\InvoicePaymentFactory'
+            - '@Aligent\InvoiceBundle\Form\Handler\InvoicePaymentFormHandler'
+            - '@Aligent\InvoiceBundle\Manager\PaymentManager'
         calls:
             - ['setContainer', ['@Psr\Container\ContainerInterface']]
         tags:

--- a/src/Aligent/InvoiceBundle/Resources/config/oro/datagrids.yml
+++ b/src/Aligent/InvoiceBundle/Resources/config/oro/datagrids.yml
@@ -35,17 +35,17 @@ datagrids:
                 label: aligent.invoice.status.label
                 type: twig
                 frontend_type: html
-                template: AligentInvoiceBundle:Datagrid/Property:status.html.twig
+                template: '@AligentInvoice/Datagrid/Property/status.html.twig'
             issueDate:
                 label: aligent.invoice.issue_date.label
                 type: twig
                 frontend_type: html
-                template: AligentInvoiceBundle:Datagrid/Property:date.html.twig
+                template: '@AligentInvoice/Datagrid/Property/date.html.twig'
             dueDate:
                 label: aligent.invoice.due_date.label
                 type: twig
                 frontend_type: html
-                template: AligentInvoiceBundle:Datagrid/Property:date.html.twig
+                template: '@AligentInvoice/Datagrid/Property/date.html.twig'
             amount:
                 label: aligent.invoice.amount.label
                 frontend_type: currency
@@ -243,12 +243,12 @@ datagrids:
                 label: oro.payment.paymenttransaction.paymentMethod.label
                 type: twig
                 frontend_type: html
-                template: 'OroPaymentBundle:PaymentTransaction/Datagrid:paymentMethod.html.twig'
+                template: '@OroPayment/PaymentTransaction/Datagrid/paymentMethod.html.twig'
             action:
                 label: oro.payment.paymenttransaction.action.label
                 type: twig
                 frontend_type: html
-                template: 'OroPaymentBundle:PaymentTransaction/Datagrid:action.html.twig'
+                template: '@OroPayment/PaymentTransaction/Datagrid/action.html.twig'
             successful:
                 label: oro.payment.paymenttransaction.successful.label
                 frontend_type: boolean
@@ -296,7 +296,7 @@ datagrids:
                 label: aligent.invoice.status.label
                 type: twig
                 frontend_type: html
-                template: AligentInvoiceBundle:Datagrid/Property:status.html.twig
+                template: '@AligentInvoice/Datagrid/Property/status.html.twig'
             amount:
                 label: aligent.invoice.amount.label
                 frontend_type: currency
@@ -307,17 +307,17 @@ datagrids:
                 label: aligent.invoice.issue_date.label
                 type: twig
                 frontend_type: html
-                template: AligentInvoiceBundle:Datagrid/Property:date.html.twig
+                template: '@AligentInvoice/Datagrid/Property/date.html.twig'
             dueDate:
                 label: aligent.invoice.due_date.label
                 type: twig
                 frontend_type: html
-                template: AligentInvoiceBundle:Datagrid/Property:date.html.twig
+                template: '@AligentInvoice/Datagrid/Property/date.html.twig'
             paymentAmount:
                 label: aligent.invoice.frontend.payment.line_items.payment_amount.label
                 type: twig
                 frontend_type: html
-                template: AligentInvoiceBundle:Datagrid/Property:amountInput.html.twig
+                template: '@AligentInvoice/Datagrid/Property/amountInput.html.twig'
         properties:
             id: ~
             view_link:

--- a/src/Aligent/InvoiceBundle/Resources/config/services.yml
+++ b/src/Aligent/InvoiceBundle/Resources/config/services.yml
@@ -149,3 +149,9 @@ services:
         calls:
             - [ 'addAction', [ !php/const Oro\Bundle\PaymentBundle\Method\PaymentMethodInterface::PURCHASE, '@oro_payment.action.purchase' ] ]
             - [ 'addAction', [ !php/const Oro\Bundle\PaymentBundle\Method\PaymentMethodInterface::VALIDATE, '@oro_payment.action.validate' ] ]
+
+    # Twig Extensions
+    Aligent\InvoiceBundle\Twig\DateTimeExtension:
+        parent: oro_locale.twig.date_time
+        tags:
+            - { name: twig.extension }

--- a/src/Aligent/InvoiceBundle/Resources/views/AligentInvoice/index.html.twig
+++ b/src/Aligent/InvoiceBundle/Resources/views/AligentInvoice/index.html.twig
@@ -1,8 +1,8 @@
-{% extends 'OroUIBundle:actions:index.html.twig' %}
-{% import 'OroUIBundle::macros.html.twig' as UI %}
+{% extends '@OroUI/actions/index.html.twig' %}
+{% import '@OroUI/macros.html.twig' as UI %}
 {% set gridName = 'aligent-invoices-grid' %}
 {% set pageTitle = 'aligent.invoice.entity_plural_label'|trans %}
 
 {% block navButtons %}
-    {% import 'OroUIBundle::macros.html.twig' as UI %}
+    {% import '@OroUI/macros.html.twig' as UI %}
 {% endblock %}

--- a/src/Aligent/InvoiceBundle/Resources/views/AligentInvoice/view.html.twig
+++ b/src/Aligent/InvoiceBundle/Resources/views/AligentInvoice/view.html.twig
@@ -1,5 +1,5 @@
-{% extends 'OroUIBundle:actions:view.html.twig' %}
-{% import 'OroDataGridBundle::macros.html.twig' as dataGrid %}
+{% extends '@OroUI/actions/view.html.twig' %}
+{% import '@OroDataGrid/macros.html.twig' as dataGrid %}
 
 {% oro_title_set({params : {"%invoiceNo%": entity.invoiceNo } }) %}
 
@@ -15,7 +15,7 @@
 {% endblock pageHeader %}
 
 {% block content_data %}
-    {% import 'OroUIBundle::macros.html.twig' as UI %}
+    {% import '@OroUI/macros.html.twig' as UI %}
 
     {% set invoiceGeneraLeft %}
         {{ UI.renderProperty('aligent.invoice.invoice_no.label'|trans, entity.invoiceNo) }}

--- a/src/Aligent/InvoiceBundle/Resources/views/Datagrid/Property/status.html.twig
+++ b/src/Aligent/InvoiceBundle/Resources/views/Datagrid/Property/status.html.twig
@@ -1,6 +1,6 @@
 <span class="invoice-grid-status-{{value}}">
     {{ value|trans_enum('invoice_status') }}
     {% if (value == constant('\\Aligent\\InvoiceBundle\\Entity\\Invoice::STATUS_OVERDUE')) %}
-        <br>({{ record.getValue('dueDate')|oro_datetime_since }})
+        <br>({{ record.getValue('dueDate')|aligent_datetime_since }})
     {% endif %}
 </span>

--- a/src/Aligent/InvoiceBundle/Resources/views/layouts/default/aligent_invoice_frontend_view/layout.html.twig
+++ b/src/Aligent/InvoiceBundle/Resources/views/layouts/default/aligent_invoice_frontend_view/layout.html.twig
@@ -14,7 +14,7 @@
     <span {{ block('block_attributes') }}>
         {{- block_widget(block) -}}
         {% if (text.id == constant('\\Aligent\\InvoiceBundle\\Entity\\Invoice::STATUS_OVERDUE')) %}
-            ({{ due_date|oro_datetime_since }})
+            ({{ due_date|aligent_datetime_since }})
         {% endif %}
     </span>
 {% endblock %}
@@ -28,7 +28,7 @@
 {% endblock %}
 
 {% block address_widget %}
-    {% from 'OroAddressBundle::macros.html.twig' import renderAddress %}
+    {% from '@OroAddress/macros.html.twig' import renderAddress %}
     {{ renderAddress(address, true) }}
 {% endblock %}
 

--- a/src/Aligent/InvoiceBundle/Twig/DateTimeExtension.php
+++ b/src/Aligent/InvoiceBundle/Twig/DateTimeExtension.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @category  Aligent
+ * @package
+ * @author    Chris Rossi <chris.rossi@aligent.com.au>
+ * @copyright 2022 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+namespace Aligent\InvoiceBundle\Twig;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Oro\Bundle\LocaleBundle\Twig\DateTimeExtension as BaseDateTimeExtension;
+use Psr\Container\ContainerExceptionInterface;
+use Twig\TwigFilter;
+
+class DateTimeExtension extends BaseDateTimeExtension
+{
+    const FUTURE_DATE_FORMAT = 'In %s';
+    const PAST_DATE_FORMAT = '%s ago';
+
+    protected ?\DateTimeZone $timezone = null;
+
+    /**
+     * @return TwigFilter[]
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('aligent_datetime_since', [$this, 'sinceDateTime']),
+            new TwigFilter('aligent_datetime_is_past', [$this, 'dateTimeIsPast']),
+        ];
+    }
+
+    /**
+     * Determine how long since the provided DateTime.
+     * Uses Carbon's diffForHumans function.
+     * Examples include:
+     *      - '3 seconds ago'
+     *      - '2 hours ago'
+     *      - '3 days ago'
+     *      - 'In 3 days'
+     *      - 'In 1 month'
+     *
+     * @param string|\DateTime $date
+     * @param array<string,mixed> $options Currently unused
+     * @return string|null
+     */
+    public function sinceDateTime(mixed $date, array $options = []): ?string
+    {
+        if (!$date) {
+            return null;
+        }
+
+        $instance = $this->getCarbonInstanceFromDate($date);
+
+        $diffString = $instance->diffForHumans([
+            'syntax' => CarbonInterface::DIFF_ABSOLUTE
+        ]);
+
+        if ($instance->isFuture()) {
+            // Is in future
+            return sprintf(self::FUTURE_DATE_FORMAT, $diffString);
+        }
+
+        // Is in past
+        return sprintf(self::PAST_DATE_FORMAT, $diffString);
+    }
+
+    /**
+     * Determine whether the provided DateTime is in the past
+     * @param \DateTime|string $date
+     * @param array<string,mixed> $options Currently unused
+     * @return bool|null
+     */
+    public function dateTimeIsPast(mixed $date, array $options = []): ?bool
+    {
+        if (!$date) {
+            return null;
+        }
+
+        $instance = $this->getCarbonInstanceFromDate($date);
+        return $instance->isPast();
+    }
+
+    /**
+     * Convert a date (DateTime or string) to a Carbon Instance
+     * @param \DateTime|string $date
+     * @return Carbon
+     */
+    protected function getCarbonInstanceFromDate(mixed $date): Carbon
+    {
+        if ($date instanceof \DateTime) {
+            return Carbon::instance($date)->shiftTimezone($this->getConfiguredTimeZone());
+        }
+
+        // String
+        return Carbon::parse($date);
+    }
+
+    protected function getConfiguredTimeZone(): ?\DateTimeZone
+    {
+        if ($this->timezone === null) {
+            try {
+                $configManager = $this->getConfigManager();
+                $this->timezone = new \DateTimeZone($configManager->get('oro_locale.timezone'));
+            } catch (ContainerExceptionInterface $e) {
+                // Not worrying with exception logging here as it's pretty unlikely
+                // that configManager will be unavailable
+            }
+        }
+
+        return $this->timezone;
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     */
+    protected function getConfigManager(): ConfigManager
+    {
+        return $this->container->get('oro_config.global');
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getSubscribedServices(): array
+    {
+        return array_merge(
+            [
+                'oro_config.global',
+            ],
+            parent::getSubscribedServices(),
+        );
+    }
+}


### PR DESCRIPTION
### Description
This PR includes OroCommerce 5.0.X fixes made against the original unmodified 4.2.X version of this Bundle (pushed in #3).

### Changes Made
* Update `FrontendInvoiceController` to use service injection instead of container
* Remove unnecessary `FlashMessageHelper` from `FrontendInvoiceController`
* Update all old Twig paths to new annotation
* Add `DateTimeExtension` to add missing Twig functions
* Rename `oro_datetime_since` Twig function to `aligent_datetime_since` to ensure globally unique
* Minor code quality improvements
* Lock PHPStan to 1.8.X to remove PHPStan 1.7.X false alarms in `--prefer-lowest` static analysis

### Notes
* This has been fully tested on OroCommerce 5.0.4 Community Edition, including storefront/backoffice features, and Invoice Payments
* This PR targets the `feature/initial-codebase-commit` branch as it builds upon that code, however PR #1 and #3 have not yet been merged. It can be retargeted once those have been approved and merged into `main`.